### PR TITLE
consolidate tag labels, add instructions to projects tab

### DIFF
--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -176,6 +176,15 @@ const Projects = ({ projects, allTags }) => {
   return (
     <AnimationLayout>
       <BowlingAlley>
+        <div
+          style={{
+            marginBottom: "1rem",
+            width: "100%",
+            textAlign: "center",
+          }}
+        >
+          <i>Click on tags to filter projects by category or language.</i>
+        </div>
         <div style={{ marginBottom: "1rem" }}>
           {allTags.map((tag, i) => {
             return <TagBubble key={i} tag={tag} onClick={addToTagList(tag)} />;
@@ -231,14 +240,16 @@ export async function getStaticProps() {
 
   let allTags = (() => {
     let tagSet = new Set();
-    let tags = projects.flatMap(project => {
-      return project.frontmatter.tags.filter((tag) => {
-        if (!tagSet.has(tag)) {
-          tagSet.add(tag);
+    let tags = projects.flatMap((project) => {
+      const addOnce = (str) => {
+        if (!tagSet.has(str)) {
+          tagSet.add(str);
           return true;
         }
         return false;
-      });
+      };
+
+      return project.frontmatter.tags.filter(tag => addOnce(tag)).concat(project.frontmatter.languages.filter(lang => addOnce(lang)));
     });
     return tags.sort();
   })();

--- a/src/pages/solutions.js
+++ b/src/pages/solutions.js
@@ -103,13 +103,15 @@ export async function getStaticProps() {
   let allTags = (() => {
     let tagSet = new Set();
     let tags = posts.flatMap((post) => {
-      return post.frontmatter.tags.filter((tag) => {
-        if (!tagSet.has(tag)) {
-          tagSet.add(tag);
+      const addOnce = (str) => {
+        if (!tagSet.has(str)) {
+          tagSet.add(str);
           return true;
         }
         return false;
-      });
+      };
+
+      return post.frontmatter.tags.filter(tag => addOnce(tag)).concat(post.frontmatter.languages.filter(lang => addOnce(lang)));
     });
     return tags.sort();
   })();

--- a/static_media/projects/graph-music.mdx
+++ b/static_media/projects/graph-music.mdx
@@ -5,7 +5,7 @@ excerpt: "When you're tired of 808s and want your drum machine to be a labelled 
 date: '2023-01-18'
 thumbnail: '/images/projects/GraphPicture.png'
 tags: ['Automaton', 'State Machine', 'Music Generation']
-languages: ['JavaScript', 'C++', 'HTML', 'CSS']
+languages: ['JavaScript', 'C++', 'HTML', 'CSS', p5.js]
 demolink: "https://gaelanmcmillan.github.io/dub-dragon-web/"
 demoimg: "/images/projects/GraphDemo.png"
 gitlink: "https://github.com/gaelanmcmillan/dub-dragon-web"

--- a/static_media/projects/wavey.mdx
+++ b/static_media/projects/wavey.mdx
@@ -5,7 +5,7 @@ excerpt: "A bot that uses Discord's message API and Google's text-to-speech API 
 date: '2022-05-05'
 thumbnail: '/images/projects/WaveyPicture.png'
 tags: ['ffmpeg', 'Bot', 'Microservice', 'Music']
-languages: ['Python']
+languages: ['Python3']
 gitlink: "https://github.com/gaelanmcmillan/wavey-bot"
 body: |
       A bot that uses Discord's message API and Google's text-to-speech API to play an interactive ear training game with server-goers. Made during RUHacks '22 

--- a/static_media/solutions/1790c-premutation.mdx
+++ b/static_media/solutions/1790c-premutation.mdx
@@ -2,7 +2,7 @@
 title: '1790C: Premutation'
 url: 'https://codeforces.com/contest/1790/problem/C'
 author: 'CodeForces'
-tags: ['Deduction', 'Brute Force', 'Permutation'] 
+tags: ['Deduction', 'Brute Force', 'Permutations'] 
 languages: ['C++']
 difficulty: medium
 date: '2023-01-27'

--- a/static_media/solutions/cheapest-flights-within-k-stops.mdx
+++ b/static_media/solutions/cheapest-flights-within-k-stops.mdx
@@ -8,7 +8,6 @@ tags:
     "Priority Queue",
     "Dijkstra's",
     "Weighted Graph",
-    "Limited Length Path",
   ]
 languages: ["C++"]
 difficulty: "medium"

--- a/static_media/solutions/lexicographically-smallest-equivalent-substring.mdx
+++ b/static_media/solutions/lexicographically-smallest-equivalent-substring.mdx
@@ -2,7 +2,7 @@
 title: "Lexicographically Smallest Equivalent Substring"
 url: "https://leetcode.com/problems/lexicographically-smallest-equivalent-string"
 author: "LeetCode"
-tags: ["Disjoint Set Union", "Hash Map"]
+tags: ["Disjoint Set Union", "Hash Table"]
 languages: ["C++"]
 difficulty: "medium"
 date: "2023-01-25"


### PR DESCRIPTION
Some tag labels were redundant, differing only in pluralization or case.
The *Projects* page lacked an instruction line at the top.